### PR TITLE
Use `internalChecksFilter` with `stabilityDays`

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,6 +2,7 @@
     "extends": ["config:base"],
     "labels": ["dependencies"],
     "stabilityDays": 5,
+    "internalChecksFilter": "strict",
     "prCreation": "not-pending",
     "prNotPendingHours": 1,
     "prConcurrentLimit": 6,


### PR DESCRIPTION
`stabilityDays` alone only adds a status check to a branch. In
combination with `prCreation="not-pending"`, this should result in PRs
only being created once X days have passed and the dependency is
considered 'stable'. However this behaviour doesn't work with groups as
explained here: https://github.com/renovatebot/config-help/issues/572

Additionally, the status check is mostly helpful when dealing with
automerging which we don't currently use. The original intention of
using `stabilityDays` was to ignore just published dependencies for
security and stability of new packages.

Using `internalChecksFilter` in tandem should achieve this original
goal. Now any 'pending' releases will be filtered, and PRs will be
skipped unless a non-pending version is available.

![image](https://user-images.githubusercontent.com/29142528/160542778-2942c7e3-c1d3-48f6-874b-679deee51529.png)

https://docs.renovatebot.com/configuration-options/#internalchecksfilter
https://docs.renovatebot.com/configuration-options/#stabilitydays